### PR TITLE
rustfmt, clippy warnings, docs.rs improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,7 @@ required-features = ["hyper_rustls"]
 name = "async_rustls"
 path = "examples/async_rustls.rs"
 required-features = ["async_std_rustls"]
+
+
+[package.metadata.docs.rs]
+features = ["use_rustls"]

--- a/examples/hyper_rustls.rs
+++ b/examples/hyper_rustls.rs
@@ -1,29 +1,38 @@
-use tokio::time::sleep;
 use async_acme::{
-    acme::{ACME_TLS_ALPN_NAME, AcmeError, LETS_ENCRYPT_STAGING_DIRECTORY},
-    rustls_helper::{order, duration_until_renewal_attempt}
+    acme::{AcmeError, ACME_TLS_ALPN_NAME, LETS_ENCRYPT_STAGING_DIRECTORY},
+    rustls_helper::{duration_until_renewal_attempt, order},
 };
+use tokio::time::sleep;
 
 use async_stream::stream;
 use core::task::{Context, Poll};
 use futures_util::{future::TryFutureExt, stream::Stream};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use rustls::{sign::CertifiedKey, ClientHello, NoClientAuth, ResolvesServerCert, ServerConfig};
 use std::pin::Pin;
+use std::{
+    collections::HashMap,
+    io,
+    path::PathBuf,
+    sync::{Arc, RwLock, Weak},
+    vec::Vec,
+};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{server::TlsStream, TlsAcceptor};
-use rustls::{sign::CertifiedKey, ClientHello, ResolvesServerCert, NoClientAuth, ServerConfig};
-use std::{path::PathBuf, io, sync::{Arc, Weak, RwLock}, vec::Vec,collections::HashMap};
-
 
 #[tokio::main]
 async fn main() {
     pretty_env_logger::init();
     // Build TLS configuration.
     let mut cfg = ServerConfig::new(NoClientAuth::new());
-    cfg.set_protocols(&[b"h2".to_vec(), b"http/1.1".to_vec(), ACME_TLS_ALPN_NAME.to_vec()]);
+    cfg.set_protocols(&[
+        b"h2".to_vec(),
+        b"http/1.1".to_vec(),
+        ACME_TLS_ALPN_NAME.to_vec(),
+    ]);
     let cres = Arc::new(ResolveServerCert::new());
-    let certres= Arc::downgrade(&cres);
+    let certres = Arc::downgrade(&cres);
     cfg.cert_resolver = cres;
     let tls_cfg = Arc::new(cfg);
 
@@ -33,7 +42,7 @@ async fn main() {
         uri: LETS_ENCRYPT_STAGING_DIRECTORY.to_string(),
         contact: vec!["mailto:admin@example.com".to_string()],
         cache_dir: None,
-        dns_names: vec!["example.com".to_string()]
+        dns_names: vec!["example.com".to_string()],
     };
     tokio::spawn(async move {
         task.acme_watcher().await;
@@ -90,8 +99,8 @@ impl AcmeTaskRunner {
                     break;
                 }
                 Some(resolver) => {
-                    //check how long the current cert is still valid                    
-                    let default = resolver.cert.read().unwrap();                    
+                    //check how long the current cert is still valid
+                    let default = resolver.cert.read().unwrap();
                     duration_until_renewal_attempt(default.as_ref(), err_cnt)
                 }
             };
@@ -100,15 +109,18 @@ impl AcmeTaskRunner {
                 sleep(d).await;
             }
             match order(
-                |k,v|self.set_auth_key(k,v),
+                |k, v| self.set_auth_key(k, v),
                 &self.uri,
                 &self.dns_names,
                 self.cache_dir.as_ref(),
-                &self.contact).await {
+                &self.contact,
+            )
+            .await
+            {
                 Err(e) => {
                     eprintln!("ACME {}", e);
                     err_cnt += 1;
-                },
+                }
                 Ok(cert_key) => {
                     //let pk_pem = cert.serialize_private_key_pem();
                     //Self::save_certified_key(cache_dir, file_name, pk_pem, acme_cert_pem).await;
@@ -127,13 +139,13 @@ impl AcmeTaskRunner {
             }
         }
     }
-    fn set_auth_key(&self, key: String, cert: CertifiedKey) -> Result<(),AcmeError> {
+    fn set_auth_key(&self, key: String, cert: CertifiedKey) -> Result<(), AcmeError> {
         match self.certres.upgrade() {
             Some(resolver) => {
                 resolver.acme_keys.write().unwrap().insert(key, cert);
                 Ok(())
-            },
-            None => Err(std::io::Error::new(io::ErrorKind::BrokenPipe,"TLS shut down").into())
+            }
+            None => Err(std::io::Error::new(io::ErrorKind::BrokenPipe, "TLS shut down").into()),
         }
     }
 }
@@ -143,19 +155,15 @@ impl ResolvesServerCert for ResolveServerCert {
         if client_hello.alpn() == Some(&[ACME_TLS_ALPN_NAME]) {
             //return a not yet signed cert
             return match client_hello.server_name() {
-                None => {
-                    None
-                }
-                Some(domain) => {
-                    self.acme_keys.read().unwrap().get(domain.into()).cloned()
-                }
-            }
+                None => None,
+                Some(domain) => self.acme_keys.read().unwrap().get(domain.into()).cloned(),
+            };
         };
 
         //do your thing to resolve your cert
         if let Some(ks) = self.cert.read().unwrap().as_ref() {
             Some(ks.clone())
-        }else{
+        } else {
             None
         }
     }

--- a/src/acme/account.rs
+++ b/src/acme/account.rs
@@ -16,12 +16,12 @@ use base64::URL_SAFE_NO_PAD;
 
 use serde_json::json;
 
-use crate::acme::{
-    get_header, AcmeError, Auth, Challenge, ChallengeType, Directory, Identifier, Order,
+use crate::{
+    acme::{get_header, AcmeError, Auth, Challenge, ChallengeType, Directory, Identifier, Order},
+    crypto::{sha256_hasher, EcdsaP256SHA256KeyPair},
+    fs::{create_dir_all, read_if_exist, write_file},
+    jose::{jose_req, key_authorization_sha256},
 };
-use crate::crypto::{sha256_hasher, EcdsaP256SHA256KeyPair};
-use crate::fs::{create_dir_all, read_if_exist, write_file};
-use crate::jose::{jose_req, key_authorization_sha256};
 use generic_async_http_client::Response;
 use std::path::Path;
 
@@ -100,7 +100,7 @@ impl Account {
             directory,
         })
     }
-    fn cached_key_file_name(contact: &Vec<&str>) -> String {
+    fn cached_key_file_name(contact: &[&str]) -> String {
         let mut ctx = sha256_hasher();
         for el in contact {
             ctx.update(el.as_ref());
@@ -122,7 +122,7 @@ impl Account {
     }
     /// send a new order for the DNS identifiers in domains
     pub async fn new_order(&self, domains: Vec<String>) -> Result<Order, AcmeError> {
-        let domains: Vec<Identifier> = domains.into_iter().map(|d| Identifier::Dns(d)).collect();
+        let domains: Vec<Identifier> = domains.into_iter().map(Identifier::Dns).collect();
         let payload = format!("{{\"identifiers\":{}}}", serde_json::to_string(&domains)?);
         let mut response = self.request(&self.directory.new_order, &payload).await?;
         Ok(response.json().await?)
@@ -155,12 +155,11 @@ impl Account {
     /// the hash needs to be presented inside the TLS certificate when the ACME TLS ALPN is present
     pub fn tls_alpn_01<'a>(
         &self,
-        challenges: &'a Vec<Challenge>,
+        challenges: &'a [Challenge],
     ) -> Result<(&'a Challenge, impl AsRef<[u8]>), AcmeError> {
         let challenge = challenges
             .iter()
-            .filter(|c| c.typ == ChallengeType::TlsAlpn01)
-            .next();
+            .find(|c| c.typ == ChallengeType::TlsAlpn01);
         let challenge = match challenge {
             Some(challenge) => challenge,
             None => return Err(AcmeError::NoTlsAlpn01Challenge),

--- a/src/acme/account.rs
+++ b/src/acme/account.rs
@@ -14,14 +14,16 @@ An ACME Account
 
 use base64::URL_SAFE_NO_PAD;
 
-use serde_json::json; 
+use serde_json::json;
 
-use crate::jose::{jose_req, key_authorization_sha256};
-use crate::acme::{AcmeError, ChallengeType, Directory, get_header, Order, Identifier, Auth, Challenge};
-use generic_async_http_client::{Response};
-use crate::crypto::{EcdsaP256SHA256KeyPair, sha256_hasher};
-use std::path::Path;
+use crate::acme::{
+    get_header, AcmeError, Auth, Challenge, ChallengeType, Directory, Identifier, Order,
+};
+use crate::crypto::{sha256_hasher, EcdsaP256SHA256KeyPair};
 use crate::fs::{create_dir_all, read_if_exist, write_file};
+use crate::jose::{jose_req, key_authorization_sha256};
+use generic_async_http_client::Response;
+use std::path::Path;
 
 #[derive(Debug)]
 pub struct Account {
@@ -67,11 +69,17 @@ impl Account {
                             write_file(cache_dir, &file, data).await?;
                         }
                         EcdsaP256SHA256KeyPair::load(data)
-                    },
-                    Err(_) => Err(())
+                    }
+                    Err(_) => Err(()),
                 }
             }
-        }.map_err(|_|AcmeError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, "could not create key pair")))?;
+        }
+        .map_err(|_| {
+            AcmeError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "could not create key pair",
+            ))
+        })?;
         let payload = json!({
             "termsOfServiceAgreed": true,
             "contact": contact,
@@ -83,7 +91,8 @@ impl Account {
             &directory.nonce().await?,
             &directory.new_account,
             &payload,
-        ).await?;
+        )
+        .await?;
         let kid = get_header(&response, "Location")?;
         Ok(Account {
             key_pair,
@@ -108,7 +117,8 @@ impl Account {
             &self.directory.nonce().await?,
             url.as_ref(),
             payload,
-        ).await
+        )
+        .await
     }
     /// send a new order for the DNS identifiers in domains
     pub async fn new_order(&self, domains: Vec<String>) -> Result<Order, AcmeError> {

--- a/src/acme/mod.rs
+++ b/src/acme/mod.rs
@@ -1,5 +1,5 @@
+use generic_async_http_client::{Error as HTTPError, Request, Response};
 use serde::{Deserialize, Serialize};
-use generic_async_http_client::{Request, Response, Error as HTTPError};
 use std::convert::TryInto;
 use thiserror::Error;
 mod account;
@@ -10,7 +10,6 @@ pub const LETS_ENCRYPT_STAGING_DIRECTORY: &str =
 pub const LETS_ENCRYPT_PRODUCTION_DIRECTORY: &str =
     "https://acme-v02.api.letsencrypt.org/directory";
 pub const ACME_TLS_ALPN_NAME: &[u8] = b"acme-tls/1";
-
 
 /// An ACME directory. Containing the REST endpoints of an ACME provider
 #[derive(Debug, Clone, Deserialize)]
@@ -26,8 +25,7 @@ impl Directory {
         Ok(Request::get(&url).exec().await?.json().await?)
     }
     pub async fn nonce(&self) -> Result<String, AcmeError> {
-        let response = Request::get(&self.new_nonce.as_str())
-            .exec().await?;
+        let response = Request::get(&self.new_nonce.as_str()).exec().await?;
         get_header(&response, "replay-nonce")
     }
 }
@@ -101,12 +99,13 @@ pub enum AcmeError {
     HttpStatus(u16),
     #[cfg(feature = "use_rustls")]
     #[error("Could not create Certificate: {0}")]
-    RcgenError(#[from] rcgen::RcgenError)
+    RcgenError(#[from] rcgen::RcgenError),
 }
 
 /// parse a HTTP header as String or fail
 fn get_header(response: &Response, header: &'static str) -> Result<String, AcmeError> {
-    response.header(header)
-        .and_then(|hv|hv.try_into().ok())
+    response
+        .header(header)
+        .and_then(|hv| hv.try_into().ok())
         .ok_or_else(|| AcmeError::MissingHeader(header))
 }

--- a/src/acme/mod.rs
+++ b/src/acme/mod.rs
@@ -22,10 +22,10 @@ pub struct Directory {
 
 impl Directory {
     pub async fn discover(url: &str) -> Result<Self, AcmeError> {
-        Ok(Request::get(&url).exec().await?.json().await?)
+        Ok(Request::get(url).exec().await?.json().await?)
     }
     pub async fn nonce(&self) -> Result<String, AcmeError> {
-        let response = Request::get(&self.new_nonce.as_str()).exec().await?;
+        let response = Request::get(self.new_nonce.as_str()).exec().await?;
         get_header(&response, "replay-nonce")
     }
 }
@@ -107,5 +107,5 @@ fn get_header(response: &Response, header: &'static str) -> Result<String, AcmeE
     response
         .header(header)
         .and_then(|hv| hv.try_into().ok())
-        .ok_or_else(|| AcmeError::MissingHeader(header))
+        .ok_or(AcmeError::MissingHeader(header))
 }

--- a/src/crypto/dummy.rs
+++ b/src/crypto/dummy.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 fn print_err() {
     println!("no crypto backend selected");
     eprintln!("no crypto backend selected");
@@ -15,7 +17,7 @@ impl EcdsaP256SHA256KeyPair {
         print_err();
         std::result::Result::<&[u8], ()>::Err(())
     }
-    pub fn sign(&self, message: &[u8]) -> Result<impl AsRef<[u8]>, ()> {
+    pub fn sign(&self, _message: &[u8]) -> Result<impl AsRef<[u8]>, ()> {
         std::result::Result::<&[u8], ()>::Err(())
     }
     pub fn public_key(&self) -> &'static [u8] {
@@ -47,7 +49,7 @@ pub fn gen_acme_cert(_domains: Vec<String>, _acme_hash: &[u8]) -> Result<Identit
 
 pub struct CertBuilder {}
 impl CertBuilder {
-    pub fn gen_new(domains: Vec<String>) -> Result<CertBuilder, ()> {
+    pub fn gen_new(_domains: Vec<String>) -> Result<CertBuilder, ()> {
         print_err();
         Err(())
     }
@@ -57,7 +59,7 @@ impl CertBuilder {
     pub fn private_key_as_pem_pkcs8(&self) -> String {
         "".to_string()
     }
-    pub fn sign(self, mut pem_cert: &[u8]) -> Result<Identity, ()> {
+    pub fn sign(self, _pem_cert: &[u8]) -> Result<Identity, ()> {
         Err(())
     }
 }

--- a/src/crypto/dummy.rs
+++ b/src/crypto/dummy.rs
@@ -1,5 +1,4 @@
-fn print_err()
-{
+fn print_err() {
     println!("no crypto backend selected");
     eprintln!("no crypto backend selected");
 }
@@ -16,8 +15,7 @@ impl EcdsaP256SHA256KeyPair {
         print_err();
         std::result::Result::<&[u8], ()>::Err(())
     }
-    pub fn sign(&self, message: &[u8],
-    ) -> Result<impl AsRef<[u8]>, ()> {
+    pub fn sign(&self, message: &[u8]) -> Result<impl AsRef<[u8]>, ()> {
         std::result::Result::<&[u8], ()>::Err(())
     }
     pub fn public_key(&self) -> &'static [u8] {
@@ -29,34 +27,31 @@ pub fn sha256(_a: &[u8]) -> &'static [u8] {
     print_err();
     &[]
 }
-pub struct DummyHash{}
+pub struct DummyHash {}
 pub fn sha256_hasher() -> DummyHash {
     print_err();
-    DummyHash{}
+    DummyHash {}
 }
 impl DummyHash {
-    pub fn update(&mut self, _a: &[u8])
-    {}
-    pub fn finish(self) -> &'static [u8]
-    {
+    pub fn update(&mut self, _a: &[u8]) {}
+    pub fn finish(self) -> &'static [u8] {
         &[]
     }
 }
 
-pub struct Identity{}
+pub struct Identity {}
 pub fn gen_acme_cert(_domains: Vec<String>, _acme_hash: &[u8]) -> Result<Identity, ()> {
     print_err();
     Err(())
 }
 
-pub struct CertBuilder {
-}
+pub struct CertBuilder {}
 impl CertBuilder {
     pub fn gen_new(domains: Vec<String>) -> Result<CertBuilder, ()> {
         print_err();
         Err(())
     }
-    pub fn get_csr(&self) -> Result<Vec<u8>,()> {
+    pub fn get_csr(&self) -> Result<Vec<u8>, ()> {
         Err(())
     }
     pub fn private_key_as_pem_pkcs8(&self) -> String {

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -3,26 +3,20 @@ use std::time::Duration;
 #[cfg(feature = "use_rustls")]
 mod ring;
 #[cfg(feature = "use_rustls")]
-pub use self::ring::{EcdsaP256SHA256KeyPair,
-    sha256_hasher, sha256,
-    gen_acme_cert, CertBuilder};
+pub use self::ring::{gen_acme_cert, sha256, sha256_hasher, CertBuilder, EcdsaP256SHA256KeyPair};
 #[cfg(feature = "use_openssl")]
 mod openssl;
 #[cfg(feature = "use_openssl")]
-pub use self::openssl::{EcdsaP256SHA256KeyPair,
-    sha256_hasher, sha256,
-    gen_acme_cert, CertBuilder};
+pub use self::openssl::{
+    gen_acme_cert, sha256, sha256_hasher, CertBuilder, EcdsaP256SHA256KeyPair,
+};
 
 use std::time::{SystemTime, UNIX_EPOCH};
 use x509_parser::parse_x509_certificate;
 
-pub fn get_cert_duration_left(x509_cert : &[u8]) -> Result<Duration,()> {
+pub fn get_cert_duration_left(x509_cert: &[u8]) -> Result<Duration, ()> {
     let valid_until = match parse_x509_certificate(x509_cert) {
-        Ok((_, cert)) => {
-            cert.validity()
-            .not_after
-            .timestamp() as u64
-        },
+        Ok((_, cert)) => cert.validity().not_after.timestamp() as u64,
         Err(_err) => {
             return Err(());
         }
@@ -38,7 +32,4 @@ pub fn get_cert_duration_left(x509_cert : &[u8]) -> Result<Duration,()> {
 #[cfg(not(any(feature = "use_rustls", feature = "use_openssl")))]
 mod dummy;
 #[cfg(not(any(feature = "use_rustls", feature = "use_openssl")))]
-pub use self::dummy::{EcdsaP256SHA256KeyPair,
-    sha256_hasher, sha256,
-    gen_acme_cert, CertBuilder};
-
+pub use self::dummy::{gen_acme_cert, sha256, sha256_hasher, CertBuilder, EcdsaP256SHA256KeyPair};

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -32,10 +32,7 @@ pub fn get_cert_duration_left(x509_cert : &[u8]) -> Result<Duration,()> {
     let since_the_epoch = start
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards");
-    //Ok(Duration::from_secs(valid_until).saturating_sub(since_the_epoch))
-    let valid_secs = (valid_until - since_the_epoch.as_secs()).max(0);
-    let wait_secs = Duration::from_secs(valid_secs as u64);
-    Ok(wait_secs)
+    Ok(Duration::from_secs(valid_until).saturating_sub(since_the_epoch))
 }
 
 #[cfg(not(any(feature = "use_rustls", feature = "use_openssl")))]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,4 +1,5 @@
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use x509_parser::parse_x509_certificate;
 
 #[cfg(feature = "use_rustls")]
 mod ring;
@@ -11,9 +12,7 @@ pub use self::openssl::{
     gen_acme_cert, sha256, sha256_hasher, CertBuilder, EcdsaP256SHA256KeyPair,
 };
 
-use std::time::{SystemTime, UNIX_EPOCH};
-use x509_parser::parse_x509_certificate;
-
+#[cfg_attr(not(feature = "use_rustls"), allow(dead_code))]
 pub fn get_cert_duration_left(x509_cert: &[u8]) -> Result<Duration, ()> {
     let valid_until = match parse_x509_certificate(x509_cert) {
         Ok((_, cert)) => cert.validity().not_after.timestamp() as u64,

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -1,18 +1,17 @@
+use openssl::hash::MessageDigest;
+pub use openssl::sha::sha256;
+use openssl::stack::Stack;
 use openssl::{
-    ec::{EcKey, EcGroup},
-    nid::{ECDSA_WITH_SHA256, SUBJECT_ALTERNATIVE_NAME},
+    ec::{EcGroup, EcKey},
     ecdsa::EcdsaSig,
+    nid::{ECDSA_WITH_SHA256, SUBJECT_ALTERNATIVE_NAME},
+    pkcs12::Pkcs12Builder,
+    pkey::PKey,
     sha::Sha256,
     x509::{
-        X509Builder, X509Extension, X509Name, X509Req, X509,
-        extension::SubjectAlternativeName
+        extension::SubjectAlternativeName, X509Builder, X509Extension, X509Name, X509Req, X509,
     },
-    pkcs12::Pkcs12Builder,
-    pkey::PKey
 };
-pub use openssl::sha::sha256;
-use openssl::hash::MessageDigest;
-use openssl::stack::Stack;
 
 use tokio_native_tls::native_tls::Identity;
 
@@ -21,22 +20,19 @@ pub struct EcdsaP256SHA256KeyPair(EcKey);
 
 impl EcdsaP256SHA256KeyPair {
     pub fn load(pkcs8: &[u8]) -> Result<EcdsaP256SHA256KeyPair, ()> {
-        match EcKey::private_key_from_pkcs8(pkcs8).and_then(|pkey|pkey.try_into()) {
-            Ok(key) => {
-                Ok(EcdsaP256SHA256KeyPair(key))
-            },
-            Err(_) => return Err(())
+        match EcKey::private_key_from_pkcs8(pkcs8).and_then(|pkey| pkey.try_into()) {
+            Ok(key) => Ok(EcdsaP256SHA256KeyPair(key)),
+            Err(_) => return Err(()),
         }
     }
     pub fn generate() -> Result<impl AsRef<[u8]>, ()> {
         let ec = EcKey::generate(EcGroup::from_curve_name(ECDSA_WITH_SHA256));
         match ec.private_key_to_pem_pkcs8() {
             Ok(vec) => Ok(vec),
-            Err(_) => Err(())
+            Err(_) => Err(()),
         }
     }
-    pub fn sign(&self, message: &[u8],
-    ) -> Result<impl AsRef<[u8]>, ErrorStack> {
+    pub fn sign(&self, message: &[u8]) -> Result<impl AsRef<[u8]>, ErrorStack> {
         EcdsaSig::sign(message, &self.0)?.to_der()
     }
     pub fn public_key(&self) -> &[u8] {
@@ -49,36 +45,33 @@ pub fn sha256_hasher() -> Sha256 {
 }
 
 pub fn gen_acme_cert(domains: Vec<String>, acme_hash: &[u8]) -> Result<Identity, ErrorStack> {
-
     let builder = X509Builder::new()?;
     let name = {
-      let mut name = X509Name::builder()?;
-      name.append_entry_by_text("CN", &domains[0])?;
-      name.build()
+        let mut name = X509Name::builder()?;
+        name.append_entry_by_text("CN", &domains[0])?;
+        name.build()
     };
     builder.set_subject_name(&name)?;
-  
+
     // Add all domains as SANs
     let san_extension = {
-      let mut san = SubjectAlternativeName::new();
-      for domain in domains.iter() {
-        san.dns(domain);
-      }
-      san.build(&builder.x509v3_context(None))?
+        let mut san = SubjectAlternativeName::new();
+        for domain in domains.iter() {
+            san.dns(domain);
+        }
+        san.build(&builder.x509v3_context(None))?
     };
     let mut stack = Stack::new()?;
     stack.push(san_extension)?;
     builder.add_extensions(&stack)?;
 
-    builder.append_extension(X509Extension::new(None,None,"1.3.6.1.5.5.7.1.31","")?)?;//OID_PE_ACME
+    builder.append_extension(X509Extension::new(None, None, "1.3.6.1.5.5.7.1.31", "")?)?; //OID_PE_ACME
 
-    let pkey = PKey::from_ec_key(
-        EcKey::generate(EcGroup::from_curve_name(ECDSA_WITH_SHA256))
-    );
+    let pkey = PKey::from_ec_key(EcKey::generate(EcGroup::from_curve_name(ECDSA_WITH_SHA256)));
 
     builder.set_pubkey(&pkey)?;
     builder.sign(&pkey, MessageDigest::sha256())?;
-  
+
     let cert = builder.build();
     Pkcs12Builder::build("", "", &pkey, &cert)?;
     Identity::from_pkcs12(der, "")?;
@@ -86,44 +79,39 @@ pub fn gen_acme_cert(domains: Vec<String>, acme_hash: &[u8]) -> Result<Identity,
 
 pub struct CertBuilder {
     req: X509Req,
-    pkey: PKey
+    pkey: PKey,
 }
 impl CertBuilder {
     pub fn gen_new(domains: Vec<String>) -> Result<CertBuilder, ErrorStack> {
         let mut builder = X509Req::builder()?;
         let name = {
-          let mut name = X509Name::builder()?;
-          name.append_entry_by_text("CN", &domains[0])?;
-          name.build()
+            let mut name = X509Name::builder()?;
+            name.append_entry_by_text("CN", &domains[0])?;
+            name.build()
         };
         builder.set_subject_name(&name)?;
-      
+
         // Add all domains as SANs
         let san_extension = {
-          let mut san = SubjectAlternativeName::new();
-          for domain in domains.iter() {
-            san.dns(domain);
-          }
-          san.build(&builder.x509v3_context(None))?
+            let mut san = SubjectAlternativeName::new();
+            for domain in domains.iter() {
+                san.dns(domain);
+            }
+            san.build(&builder.x509v3_context(None))?
         };
         let mut stack = Stack::new()?;
         stack.push(san_extension)?;
         builder.add_extensions(&stack)?;
-      
-        let pkey = PKey::from_ec_key(
-            EcKey::generate(EcGroup::from_curve_name(ECDSA_WITH_SHA256))
-        );
+
+        let pkey = PKey::from_ec_key(EcKey::generate(EcGroup::from_curve_name(ECDSA_WITH_SHA256)));
 
         builder.set_pubkey(&pkey)?;
         builder.sign(&pkey, MessageDigest::sha256())?;
-      
+
         let req = builder.build();
-        Ok(CertBuilder {
-            req,
-            pkey
-        })
+        Ok(CertBuilder { req, pkey })
     }
-    pub fn get_csr(&self) -> Result<Vec<u8>,ErrorStack> {
+    pub fn get_csr(&self) -> Result<Vec<u8>, ErrorStack> {
         self.req.to_der()
     }
     pub fn private_key_as_pem_pkcs8(&self) -> Result<Vec<u8>, ErrorStack> {

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -1,8 +1,11 @@
-use ring::digest::{Context, SHA256 as DoSHA256, digest};
-use ring::error::{Unspecified};
-use ring::rand::{SystemRandom};
-use ring::signature::{KeyPair, EcdsaKeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
-use rcgen::{DistinguishedName, CertificateParams, Certificate, CustomExtension, RcgenError, PKCS_ECDSA_P256_SHA256};
+use rcgen::{
+    Certificate, CertificateParams, CustomExtension, DistinguishedName, RcgenError,
+    PKCS_ECDSA_P256_SHA256,
+};
+use ring::digest::{digest, Context, SHA256 as DoSHA256};
+use ring::error::Unspecified;
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
 use rustls::sign::{any_ecdsa_type, CertifiedKey, SigningKey};
 use rustls::PrivateKey;
@@ -15,15 +18,16 @@ pub struct EcdsaP256SHA256KeyPair(EcdsaKeyPair);
 impl EcdsaP256SHA256KeyPair {
     pub fn load(pkcs8: &[u8]) -> Result<EcdsaP256SHA256KeyPair, ()> {
         let alg = &ECDSA_P256_SHA256_FIXED_SIGNING;
-        EcdsaKeyPair::from_pkcs8(alg, &pkcs8).map_err(|_|()).map(|kp|EcdsaP256SHA256KeyPair(kp))
+        EcdsaKeyPair::from_pkcs8(alg, &pkcs8)
+            .map_err(|_| ())
+            .map(|kp| EcdsaP256SHA256KeyPair(kp))
     }
     pub fn generate() -> Result<impl AsRef<[u8]>, ()> {
         let alg = &ECDSA_P256_SHA256_FIXED_SIGNING;
         let rng = SystemRandom::new();
-        EcdsaKeyPair::generate_pkcs8(alg, &rng).map_err(|_|())
+        EcdsaKeyPair::generate_pkcs8(alg, &rng).map_err(|_| ())
     }
-    pub fn sign(&self, message: &[u8],
-    ) -> Result<impl AsRef<[u8]>, Unspecified> {
+    pub fn sign(&self, message: &[u8]) -> Result<impl AsRef<[u8]>, Unspecified> {
         self.0.sign(&SystemRandom::new(), message)
     }
     pub fn public_key(&self) -> &[u8] {
@@ -51,7 +55,7 @@ pub fn gen_acme_cert(domains: Vec<String>, acme_hash: &[u8]) -> Result<Certified
 
 pub struct CertBuilder {
     cert: Certificate,
-    pk: Arc<dyn SigningKey>
+    pk: Arc<dyn SigningKey>,
 }
 impl CertBuilder {
     pub fn gen_new(domains: Vec<String>) -> Result<CertBuilder, RcgenError> {
@@ -61,21 +65,20 @@ impl CertBuilder {
         let cert = Certificate::from_params(params)?;
         let pk = any_ecdsa_type(&PrivateKey(cert.serialize_private_key_der())).unwrap();
 
-        Ok(CertBuilder {
-            cert,
-            pk
-        })
+        Ok(CertBuilder { cert, pk })
     }
-    pub fn get_csr(&self) -> Result<Vec<u8>,RcgenError> {
+    pub fn get_csr(&self) -> Result<Vec<u8>, RcgenError> {
         self.cert.serialize_request_der()
     }
     pub fn private_key_as_pem_pkcs8(&self) -> String {
         self.cert.serialize_private_key_pem()
     }
     pub fn sign(self, mut pem_cert: &[u8]) -> Result<CertifiedKey, ()> {
-        let cert_chain = 
-        rustls_pemfile::certs(&mut pem_cert).map_err(|_|())?
-            .drain(..).map(|v|rustls::Certificate(v)).collect();
+        let cert_chain = rustls_pemfile::certs(&mut pem_cert)
+            .map_err(|_| ())?
+            .drain(..)
+            .map(|v| rustls::Certificate(v))
+            .collect();
         let cert_key = CertifiedKey::new(cert_chain, self.pk);
         Ok(cert_key)
     }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -3,8 +3,10 @@ pub use async_std::fs::{create_dir_all as cdall, read, write};
 #[cfg(feature = "use_tokio")]
 pub use tokio::fs::{create_dir_all, read, write};
 
-use std::io::{Error, ErrorKind};
-use std::path::Path;
+use std::{
+    io::{Error, ErrorKind},
+    path::Path,
+};
 
 #[cfg(feature = "use_async_std")]
 pub async fn create_dir_all(a: impl AsRef<Path>) -> Result<(), Error> {
@@ -22,7 +24,7 @@ pub(crate) async fn read_if_exist(
         Ok(content) => Ok(Some(content)),
         Err(err) => match err.kind() {
             ErrorKind::NotFound => Ok(None),
-            _ => Err(err.into()),
+            _ => Err(err),
         },
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -3,8 +3,8 @@ pub use async_std::fs::{create_dir_all as cdall, read, write};
 #[cfg(feature = "use_tokio")]
 pub use tokio::fs::{create_dir_all, read, write};
 
+use std::io::{Error, ErrorKind};
 use std::path::Path;
-use std::io::{ErrorKind, Error};
 
 #[cfg(feature = "use_async_std")]
 pub async fn create_dir_all(a: impl AsRef<Path>) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,9 @@ Without anything specified you will end up with *no async backend selected* or *
 */
 
 pub mod acme;
-mod jose;
 mod crypto;
 mod fs;
+mod jose;
 
 #[cfg(feature = "use_rustls")]
 pub mod rustls_helper;
-


### PR DESCRIPTION
This pull request builds atop the change in #1. Outside of the commit from #1, the changes in this pull request are:

- Executed `cargo fmt`
- Fixed all warnings from `cargo clippy`
- Specifying the "use_rustls" feature flag for docs.rs. This will allow the `rustls_helper` module be visible.